### PR TITLE
Sets default SHA to GITHUB_SHA

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ fi
 TAG="${INPUT_TAG}"
 MESSAGE="${INPUT_MESSAGE:-Release ${TAG}}"
 FORCE_TAG="${INPUT_FORCE_PUSH_TAG:-false}"
-SHA=${INPUT_COMMIT_SHA:-}
+SHA=${INPUT_COMMIT_SHA:-${GITHUB_SHA}}
 
 git config user.name "${GITHUB_ACTOR}"
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"


### PR DESCRIPTION
This pull request makes sure that the default `SHA` is set to the value of `GITHU_SHA`. This was done to fix #3.