### PR TITLE
fix: apply hotfix for git security error #10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM alpine:3.15
+# NOTE: The alpine version in this container is currently fixed at 3.14 to prevent the
+# 'fatal: unsafe repository' error that was introduced in https://github.blog/2022-04-12-git-security-vulnerability-announced/.
+# See https://github.com/actions/checkout/issues/766 andhttps://github.com/rickstaa/action-create-tag/issues/10 for
+# more information.
+FROM alpine:3.14
 
 RUN apk --no-cache add git && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This pr applies a hotfix for the 'fatal: unsafe repository' error introduced in https://github.blog/2022-04-12-git-security-vulnerability-announced/. This fix can be removed when an upstream fix has been applied to the action ecosystem. See https://github.com/actions/checkout/issues/766 andhttps://github.com/rickstaa/action-create-tag/issues/10 for more
information.
