### PR TITLE
no_verify_tag option to skip verification when pushing the tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Simple GitHub action that can be used to create/update a tag and push it to the 
 
 **Optional**. Push tag even if it already exists on the remote. Default: `false`. Please use with care!
 
+### `no_verify_tag`
+
+**Optional**. Skips verifying when pushing the tag. Default: `false`. Please use with care!
+
 ### `commit_sha`
 
 **Optional**. The commit SHA hash on which you want to push the tag. Uses latest commit by default.

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: "Optional. Force push the tag. Defaults to 'false'."
     required: false
     default: "false"
+  no_verify_tag:
+    description: "Optional. Skips verifying when pushing the tag."
+    required: false
+    default: "false"
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
     default: "false"
   no_verify_tag:
-    description: "Optional. Skips verifying when pushing the tag."
+    description: "Optional. Skips verifying when pushing the tag. Defaults to 'false'."
     required: false
     default: "false"
 runs:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,7 +28,7 @@ echo "[action-create-tag] Create tag '${TAG}'."
 if [ "${FORCE_TAG}" = 'true' ]; then
   git tag -fa "${TAG}" "${SHA}" -m "${MESSAGE}"
   FLAGS="${FLAGS} --force"
-  ACTION_OUTPUT_MESSAGE="$ACTION_OUTPUT_MESSAGE, with --force"
+  ACTION_OUTPUT_MESSAGE="${ACTION_OUTPUT_MESSAGE}, with --force"
 else
   git tag -a "${TAG}" "${SHA}" -m "${MESSAGE}"
 fi
@@ -41,7 +41,7 @@ fi
 # Handle no-verify action input.
 if ["${NO_VERIFY}" = 'true' ]; then
   FLAGS="${FLAGS} --no-verify"
-  ACTION_OUTPUT_MESSAGE="$ACTION_OUTPUT_MESSAGE, with --no-verify"
+  ACTION_OUTPUT_MESSAGE="${ACTION_OUTPUT_MESSAGE}, with --no-verify"
 fi
 
 # Push tag.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ fi
 # Set up variables.
 FLAGS=""
 TAG=$(echo "${INPUT_TAG}" | sed 's/ /_/g')
-ACTION_OUTPUT_MESSAGE="[action-create-tag] Push tag ${TAG}"
+ACTION_OUTPUT_MESSAGE="[action-create-tag] Push tag '${TAG}'"
 MESSAGE="${INPUT_MESSAGE:-Release ${TAG}}"
 FORCE_TAG="${INPUT_FORCE_PUSH_TAG:-false}"
 NO_VERIFY="${INPUT_NO_VERIFY_TAG:-false}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,7 +28,7 @@ echo "[action-create-tag] Create tag '${TAG}'."
 if [ "${FORCE_TAG}" = 'true' ]; then
   git tag -fa "${TAG}" "${SHA}" -m "${MESSAGE}"
   FLAGS="${FLAGS} --force"
-  ACTION_MESSAGE="$MESSAGE, with --force"
+  ACTION_OUTPUT_MESSAGE="$ACTION_OUTPUT_MESSAGE, with --force"
 else
   git tag -a "${TAG}" "${SHA}" -m "${MESSAGE}"
 fi
@@ -41,7 +41,7 @@ fi
 # Handle no-verify action input.
 if ["${NO_VERIFY}" = 'true' ]; then
   FLAGS="${FLAGS} --no-verify"
-  MESSAGE="$MESSAGE, with --no-verify"
+  ACTION_OUTPUT_MESSAGE="$ACTION_OUTPUT_MESSAGE, with --no-verify"
 fi
 
 # Push tag.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,7 +39,7 @@ if [ -n "${INPUT_GITHUB_TOKEN}" ]; then
 fi
 
 # Handle no-verify action input.
-if ["${NO_VERIFY}" = 'true' ]; then
+if [ "${NO_VERIFY}" = 'true' ]; then
   FLAGS="${FLAGS} --no-verify"
   ACTION_OUTPUT_MESSAGE="${ACTION_OUTPUT_MESSAGE}, with --no-verify"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,7 @@ fi
 TAG="${INPUT_TAG}"
 MESSAGE="${INPUT_MESSAGE:-Release ${TAG}}"
 FORCE_TAG="${INPUT_FORCE_PUSH_TAG:-false}"
+NO_VERIFY="${INPUT_NO_VERIFY_TAG:-false}"
 SHA=${INPUT_COMMIT_SHA:-${GITHUB_SHA}}
 
 git config user.name "${GITHUB_ACTOR}"
@@ -33,11 +34,17 @@ if [ -n "${INPUT_GITHUB_TOKEN}" ]; then
   git remote set-url origin "https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 fi
 
-# Push tag
-if [ "${FORCE_TAG}" = 'true' ]; then
-  echo "[action-create-tag] Force push tag '${TAG}'."
-  git push --force origin "${TAG}"
-else
-  echo "[action-create-tag] Push tag '${TAG}'."
-  git push origin "${TAG}"
+FLAGS=""
+MESSAGE="action-create-tag] Push tag ${TAG}"
+if ["${FORCE_TAG}" = 'true' ]; then
+  FLAGS="${FLAGS} --force"
+  MESSAGE="$MESSAGE, with --foce"
 fi
+if ["${NO_VERIFY}" = 'true' ]; then
+  FLAGS="${FLAGS} --no-verify"
+  MESSAGE="$MESSAGE, with --no-verify"
+fi
+
+# Push tag
+echo $MESSAGE
+git push tag $FLAGS origin "$TAG"


### PR DESCRIPTION
When using this action, I faced a problem that git hooks are applied when pushing the tag. In order to skip verification on pushing, I would like to push with the `--no-verify` flag. In this pull request, I provided an option that allows to do so.