### PR TITLE
feat: add 'tag_exists_error' input and 'tag_exists' output #30

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Simple (docker-based) GitHub action that can be used to create/update a tag and 
 
 **Optional**. Push tag even if it already exists on the remote. Default: `false`. Please use with care!
 
+### `tag_exists_error`
+
+**Optional**. Whether to throw an error when the tag already exists. Default: `true`. Ignored when `force_push_tag` is `true`.
+
 ### `no_verify_tag`
 
 **Optional**. Skips verifying when pushing the tag. Default: `false`. Please use with care!
@@ -36,6 +40,18 @@ Simple (docker-based) GitHub action that can be used to create/update a tag and 
 
 **Optional**. It's no need to specify it if you use checkout@v2. Required for
 checkout@v1 action.
+
+## Outputs
+
+### `tag_exists`
+
+A boolean specifying whether the tag already exists.
+
+## Environment variables
+
+### `TAG_EXISTS`
+
+A boolean specifying whether the tag already exists.
 
 ## Example usage
 
@@ -50,9 +66,19 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: rickstaa/action-create-tag@v1
+        id: "tag_create"
         with:
           tag: "latest"
+          tag_exists_error: false
           message: "Latest release"
+
+      # Print result using the env variable.
+      -  run: |
+          echo "Tag already present: ${{ env.TAG_EXISTS }}"
+
+      # Print result using the action output.
+      - run: |
+          echo "Tag already present: ${{ steps.tag_create.outputs.tag_exists }}"
 ```
 
 ## Contributing

--- a/action.yml
+++ b/action.yml
@@ -18,10 +18,17 @@ inputs:
     description: "Optional. Force push the tag. Defaults to 'false'."
     required: false
     default: "false"
+  tag_exists_error:
+    description: "Optional. Whether to throw an error when the tag already exists. Defaults to 'true'."
+    required: false
+    default: "true"
   no_verify_tag:
     description: "Optional. Skips verifying when pushing the tag. Defaults to 'false'."
     required: false
     default: "false"
+outputs:
+  tag_exists:
+    description: "Whether the tag already existed."
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,7 @@ git config user.name "${GITHUB_ACTOR}"
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
 # Check if tag already exists.
-if [ $(git tag -l "${TAG}")  ]; then tag_exists=true; else tag_exists=false; fi
+if [ "$(git tag -l "${TAG}")"  ]; then tag_exists=true; else tag_exists=false; fi
 echo "tag_exists=${tag_exists}" >> "${GITHUB_OUTPUT}"
 echo "TAG_EXISTS=${tag_exists}" >> "${GITHUB_ENV}"
 
@@ -62,6 +62,7 @@ if [ "${NO_VERIFY}" = 'true' ]; then
 fi
 
 # Push tag.
-[[ "${tag_exists}" = 'true' && "${FORCE_TAG}" = 'false' ]] && exit 0
+[ "${tag_exists}" = 'true' ] && [ "${FORCE_TAG}" = 'false' ] && exit 0
 echo "${ACTION_OUTPUT_MESSAGE}"
+# shellcheck disable=SC2086
 git push $FLAGS origin "$TAG"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,20 +17,37 @@ TAG=$(echo "${INPUT_TAG}" | sed 's/ /_/g')
 ACTION_OUTPUT_MESSAGE="[action-create-tag] Push tag '${TAG}'"
 MESSAGE="${INPUT_MESSAGE:-Release ${TAG}}"
 FORCE_TAG="${INPUT_FORCE_PUSH_TAG:-false}"
+TAG_EXISTS_ERROR="${INPUT_TAG_EXISTS_ERROR:-true}"
 NO_VERIFY="${INPUT_NO_VERIFY_TAG:-false}"
 SHA=${INPUT_COMMIT_SHA:-${GITHUB_SHA}}
 
 git config user.name "${GITHUB_ACTOR}"
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
+# Check if tag already exists.
+if [ $(git tag -l "${TAG}")  ]; then tag_exists=true; else tag_exists=false; fi
+echo "tag_exists=${tag_exists}" >> "${GITHUB_OUTPUT}"
+echo "TAG_EXISTS=${tag_exists}" >> "${GITHUB_ENV}"
+
 # Create tag and handle force push action input.
 echo "[action-create-tag] Create tag '${TAG}'."
+[ "${tag_exists}" = 'true' ] && echo "[action-create-tag] Tag '${TAG}' already exists."
 if [ "${FORCE_TAG}" = 'true' ]; then
+  [ "${tag_exists}" = 'true' ] && echo "[action-create-tag] Overwriting tag '${TAG}' since 'force_push_tag' is set to 'true'."
   git tag -fa "${TAG}" "${SHA}" -m "${MESSAGE}"
   FLAGS="${FLAGS} --force"
   ACTION_OUTPUT_MESSAGE="${ACTION_OUTPUT_MESSAGE}, with --force"
 else
-  git tag -a "${TAG}" "${SHA}" -m "${MESSAGE}"
+  if [ "${tag_exists}" = 'true' ]; then
+    echo "[action-create-tag] Please set 'force_push_tag' to 'true' if you want to overwrite it."
+    if [ "${TAG_EXISTS_ERROR}" = 'true' ]; then
+      echo "[action-create-tag] Throwing an error. Please set 'tag_exists_error' to 'false' if you want to ignore this error."
+      exit 1
+    fi
+    echo "[action-create-tag] Ignoring error since 'tag_exists_error' is set to 'false'."
+  else
+    git tag -a "${TAG}" "${SHA}" -m "${MESSAGE}"
+  fi
 fi
 
 # Set up remote url for checkout@v1 action.
@@ -45,5 +62,6 @@ if [ "${NO_VERIFY}" = 'true' ]; then
 fi
 
 # Push tag.
+[[ "${tag_exists}" = 'true' && "${FORCE_TAG}" = 'false' ]] && exit 0
 echo "${ACTION_OUTPUT_MESSAGE}"
 git push $FLAGS origin "$TAG"


### PR DESCRIPTION
This PR adds the 'tag_exists_error' input, which can suppress the error thrown when a tag already exists. It also contains the 'tag_exists' output variable and the 'TAG_EXISTS' environmental variable to indicate if a tag is already present.
