### PR TITLE
Update example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ jobs:
   create-tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: rickstaa/action-create-tag@v1
         id: "tag_create"
         with:


### PR DESCRIPTION
`actions/checkout@v4` would not fetch tags if `fetch-depth` is set to 1 (even if fetch-tags is set to 'true' (see [this run](https://github.com/smg-real-estate/ds-toolkit/actions/runs/6643442688/job/18050489071)).

Thus, it's safest to set `fetch-depth` to 0.